### PR TITLE
Fix Shopify admin client REST calls

### DIFF
--- a/src/lib/shopify.ts
+++ b/src/lib/shopify.ts
@@ -372,26 +372,24 @@ export async function fetchCart(cartId: string): Promise<NormalizedCart | null> 
 
 export async function fetchShopifyProducts() {
   const client = getShopifyAdminClient();
-  const response = await client.get({
-    path: 'products',
-    query: {
+  const response = await client.get('products', {
+    searchParams: {
       limit: 250,
     },
   });
-  const body = response.body as { products?: any[] };
+  const body = (await response.json()) as { products?: any[] };
   return body.products ?? [];
 }
 
 export async function fetchShopifyOrders() {
   const client = getShopifyAdminClient();
-  const response = await client.get({
-    path: 'orders',
-    query: {
+  const response = await client.get('orders', {
+    searchParams: {
       status: 'any',
       limit: 250,
     },
   });
-  const body = response.body as { orders?: any[] };
+  const body = (await response.json()) as { orders?: any[] };
   return body.orders ?? [];
 }
 


### PR DESCRIPTION
## Summary
- update Shopify admin REST client usage to pass a path string with search params
- parse REST responses using `response.json()` before returning data

## Testing
- npm run build *(fails: unable to download Google Fonts in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dee0b760b0832eb54a3a2cd5fc1dc8