### PR TITLE
Polish storefront UI and add dummy data fallbacks

### DIFF
--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -7,6 +7,7 @@ export const revalidate = 0;
 
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
+import { getDummyProducts } from '@/lib/dummyContent';
 
 /**
  * API endpoint that returns a list of all live products. Includes each
@@ -14,9 +15,17 @@ import prisma from '@/lib/prisma';
  * render pricing, filter by season and display variant information.
  */
 export async function GET() {
-  const products = await prisma.product.findMany({
-    where: { live: true },
-    include: { variants: true, collection: { select: { season: true } } },
-  });
-  return NextResponse.json(products);
+  try {
+    const products = await prisma.product.findMany({
+      where: { live: true },
+      include: { variants: true, collection: { select: { season: true } } },
+    });
+    if (products.length > 0) {
+      return NextResponse.json(products);
+    }
+  } catch (error) {
+    console.warn('Falling back to dummy products because Prisma query failed.', error);
+  }
+
+  return NextResponse.json(getDummyProducts());
 }

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -7,6 +7,7 @@ export const revalidate = 0;
 
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
+import { getDummyProduct, getDummyReviews } from '@/lib/dummyContent';
 
 /**
  * API route for reviews. Returns reviews for a product if a productId is provided via query.
@@ -18,11 +19,23 @@ export async function GET(req: Request) {
   if (!productSlug) {
     return NextResponse.json({ error: 'Missing slug' }, { status: 400 });
   }
-  // Look up product by slug and fetch its reviews
-  const product = await prisma.product.findUnique({ where: { slug: productSlug }, select: { id: true } });
-  if (!product) {
+  try {
+    const product = await prisma.product.findUnique({ where: { slug: productSlug }, select: { id: true } });
+    if (!product) {
+      return NextResponse.json({ error: 'Product not found' }, { status: 404 });
+    }
+    const reviews = await prisma.review.findMany({
+      where: { productId: product.id },
+      orderBy: { createdAt: 'desc' },
+    });
+    return NextResponse.json(reviews);
+  } catch (error) {
+    console.warn(`Falling back to dummy reviews for ${productSlug}`, error);
+  }
+
+  const dummyProduct = getDummyProduct(productSlug);
+  if (!dummyProduct) {
     return NextResponse.json({ error: 'Product not found' }, { status: 404 });
   }
-  const reviews = await prisma.review.findMany({ where: { productId: product.id }, orderBy: { createdAt: 'desc' } });
-  return NextResponse.json(reviews);
+  return NextResponse.json(getDummyReviews(productSlug));
 }

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -13,7 +13,7 @@ import { variantImageForSku } from '@/lib/paths';
  * from Shopify.
  */
 export default function CartPage() {
-  const { items, clear, updateQty, remove, checkoutUrl, currencyCode, subtotalCents } = useCart();
+  const { items, clear, updateQty, remove, checkoutUrl, currencyCode, subtotalCents, refresh } = useCart();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -68,37 +68,47 @@ export default function CartPage() {
   }
 
   return (
-    <main className="mx-auto max-w-5xl px-4 py-10">
-      <h1 className="font-heading text-3xl mb-6">Your Cart</h1>
+    <main className="mx-auto max-w-5xl space-y-6 px-4 pb-16 pt-12">
+      <header className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-end">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-muted">Your ritual bag</p>
+          <h1 className="font-heading text-3xl text-text">Shopping bag</h1>
+        </div>
+        <button
+          onClick={handleClear}
+          className="rounded-full border border-border/70 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-text transition hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={loading || items.length === 0}
+        >
+          Clear bag
+        </button>
+      </header>
+
       {items.length === 0 ? (
-        <p>Your cart is empty.</p>
+        <div className="rounded-3xl border border-border/60 bg-white/70 p-10 text-center text-sm text-muted">
+          Your bag is feeling light. Explore the <a className="text-accent underline" href="/shop">collection</a> to begin your ritual.
+        </div>
       ) : (
-        <div className="space-y-4">
+        <div className="space-y-6">
           {items.map((item) => (
             <div
               key={item.id}
-              className="border p-4 rounded-lg flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
+              className="flex flex-col gap-4 rounded-3xl border border-border/60 bg-white/80 p-6 shadow-sm backdrop-blur sm:flex-row sm:items-center sm:justify-between"
             >
-              <div className="flex items-center gap-4 w-full sm:w-auto">
-                {/* Display the product or variant image */}
+              <div className="flex w-full items-center gap-4 sm:w-auto">
                 <img
                   src={variantImageForSku(item.sku)}
                   alt={item.title}
-                  className="w-16 h-16 object-cover rounded-md"
+                  className="h-20 w-20 rounded-2xl object-cover"
                 />
                 <div>
-                  <div className="font-medium">{item.title}</div>
-                  {item.sku && (
-                    <div className="text-sm text-gray-600">SKU: {item.sku}</div>
-                  )}
-                  <div className="text-sm text-gray-600">
-                    {formatCurrency(item.unitPriceCents)} each
-                  </div>
+                  <div className="font-semibold text-text">{item.title}</div>
+                  {item.sku && <div className="text-xs uppercase tracking-wide text-muted">{item.sku}</div>}
+                  <div className="text-sm text-muted">{formatCurrency(item.unitPriceCents)} each</div>
                 </div>
               </div>
-              <div className="flex items-center gap-4 justify-between w-full sm:w-auto">
-                <label className="text-sm text-gray-600" htmlFor={`qty-${item.id}`}>
-                  Qty:
+              <div className="flex w-full items-center justify-between gap-4 sm:w-auto">
+                <label className="text-xs uppercase tracking-wide text-muted" htmlFor={`qty-${item.id}`}>
+                  Qty
                 </label>
                 <input
                   id={`qty-${item.id}`}
@@ -106,40 +116,42 @@ export default function CartPage() {
                   min={1}
                   value={item.quantity}
                   onChange={(e) => handleQuantityChange(item.id, Number(e.target.value))}
-                  className="w-16 border rounded px-2 py-1"
+                  className="w-20 rounded-full border border-border/60 bg-white/80 px-3 py-2 text-sm text-text shadow-sm focus:outline-none focus:ring-2 focus:ring-accent/30"
                 />
                 <button
                   onClick={() => handleRemove(item.id)}
-                  className="text-red-600 hover:underline text-sm"
+                  className="text-xs font-semibold uppercase tracking-wide text-accent transition hover:opacity-80"
                 >
                   Remove
                 </button>
               </div>
-              <div className="text-right font-medium min-w-[6rem]">
+              <div className="min-w-[6rem] text-right font-semibold text-text">
                 {formatCurrency(item.lineTotalCents)}
               </div>
             </div>
           ))}
-          <div className="flex gap-4 mt-6">
-            <button
-              onClick={handleCheckout}
-              disabled={loading}
-              className="rounded-full bg-foreground text-white px-6 py-3 hover:bg-accent transition disabled:opacity-50"
-            >
-              {loading ? 'Processing…' : 'Checkout'}
-            </button>
-            <button
-              onClick={handleClear}
-              className="rounded-full border px-6 py-3 hover:bg-primary/30 transition disabled:opacity-50"
-              disabled={loading}
-            >
-              Clear Cart
-            </button>
+
+          <div className="flex flex-col items-end gap-4 rounded-3xl border border-border/60 bg-white/80 p-6 shadow-sm backdrop-blur">
+            <div className="text-sm text-muted">Subtotal</div>
+            <div className="text-2xl font-heading text-text">{formatCurrency(subtotalCents)}</div>
+            <div className="flex flex-wrap gap-3">
+              <button
+                onClick={handleCheckout}
+                disabled={loading}
+                className="rounded-full bg-accent px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:shadow-lg disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {loading ? 'Processing…' : 'Proceed to checkout'}
+              </button>
+              <button
+                onClick={refresh}
+                className="rounded-full border border-border/70 px-6 py-3 text-sm font-semibold text-text transition hover:border-accent hover:text-accent"
+              >
+                Refresh totals
+              </button>
+            </div>
           </div>
-          <div className="text-right text-lg font-semibold">
-            Subtotal: {formatCurrency(subtotalCents)}
-          </div>
-          {error && <p className="text-sm text-red-500 mt-2">{error}</p>}
+
+          {error && <p className="text-sm text-red-500">{error}</p>}
         </div>
       )}
     </main>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,4 +16,7 @@ body {
 
 body {
   @apply bg-background text-text font-body;
+  background-image:
+    radial-gradient(circle at 20% 20%, rgba(246, 236, 239, 0.7), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(124, 92, 252, 0.12), transparent 60%);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,26 +1,191 @@
 import Link from 'next/link';
+import ProductCard from '@/components/ProductCard';
+import { getDummyProducts, getDummyReviews } from '@/lib/dummyContent';
+
+const heroStats = [
+  { label: 'Feather-light finish', value: '24h' },
+  { label: 'Botanical actives', value: '6' },
+  { label: 'Vegan & cruelty free', value: '100%' },
+];
+
+const ritualSteps = [
+  {
+    title: 'Prep',
+    detail: 'Awaken skin with a mist of mineral essence to boost slip and glow.',
+  },
+  {
+    title: 'Perfect',
+    detail: 'Sweep on Weightless Mineral Foundation in light, feathered strokes.',
+  },
+  {
+    title: 'Polish',
+    detail: 'Set with Silk Veil Powder and tap Luminous Blush onto cheekbones.',
+  },
+];
+
+const ingredientHighlights = [
+  {
+    title: 'Rosehip oil',
+    body: 'Replenishes the skin barrier with essential fatty acids for lasting comfort.',
+  },
+  {
+    title: 'Rice powder',
+    body: 'Naturally blurs texture with a breathable, feather-light touch.',
+  },
+  {
+    title: 'Calendula extract',
+    body: 'Calms and soothes even sensitive complexions with anti-inflammatory properties.',
+  },
+];
 
 /**
- * Home page provides a simple introduction and directs visitors to the
- * shop. In future sprints this page could be replaced with a more
- * elaborate hero banner, mineral showcase and product carousel as
- * outlined in the design guidelines.
+ * Home page hero, ritual overview and featured products. Uses dummy content so the
+ * UI feels finished before live Shopify data and imagery arrive.
  */
 export default function Home() {
+  const products = getDummyProducts();
+  const featured = products.slice(0, 3);
+  const testimonials = getDummyReviews('weightless-mineral-foundation').slice(0, 2);
+
   return (
-    <main className="mx-auto max-w-6xl px-4 py-16 text-center">
-      <h1 className="font-heading text-5xl tracking-tight">Because You’re Beautiful</h1>
-      <p className="mt-4 text-lg text-gray-700">
-        Clean, feather-light formulas crafted from six essential minerals.
-      </p>
-      <div className="mt-8">
-        <Link
-          href="/shop"
-          className="inline-block rounded-full bg-foreground text-white px-6 py-3 hover:bg-accent transition"
-        >
-          Shop the Collection
-        </Link>
-      </div>
+    <main className="mx-auto max-w-6xl space-y-24 px-4 pb-24 pt-16">
+      <section className="relative grid gap-10 overflow-hidden rounded-[3rem] border border-border/60 bg-white/80 p-10 shadow-xl backdrop-blur sm:grid-cols-[1.2fr_1fr]">
+        <div className="flex flex-col justify-between gap-8">
+          <div className="space-y-4">
+            <span className="inline-flex items-center gap-2 rounded-full bg-highlight/80 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-text">
+              New Season • Mineral Ritual
+            </span>
+            <h1 className="font-heading text-4xl leading-tight text-text sm:text-5xl">
+              Because your glow should feel like wearing nothing at all.
+            </h1>
+            <p className="max-w-xl text-lg leading-relaxed text-muted">
+              FeatherLite formulas fuse mineral science with nourishing botanicals so every sweep feels weightless,
+              luminous and kind to skin.
+            </p>
+            <div className="flex flex-wrap gap-4">
+              <Link
+                href="/shop"
+                className="inline-flex items-center gap-2 rounded-full bg-accent px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:shadow-lg"
+              >
+                Shop the collection
+              </Link>
+              <Link
+                href="/shop?season=Spring"
+                className="inline-flex items-center gap-2 rounded-full border border-border/70 px-6 py-3 text-sm font-semibold text-text transition hover:border-accent hover:text-accent"
+              >
+                Explore seasonal edits
+              </Link>
+            </div>
+          </div>
+          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            {heroStats.map((stat) => (
+              <div key={stat.label} className="rounded-2xl border border-border/60 bg-white/60 px-4 py-3 text-center shadow-sm">
+                <dt className="text-xs uppercase tracking-wide text-muted">{stat.label}</dt>
+                <dd className="mt-1 text-2xl font-semibold text-text">{stat.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+        <div className="relative flex items-center justify-center">
+          <div className="absolute inset-4 rounded-[2.5rem] bg-gradient-to-br from-primary via-white to-accent/20" />
+          <div className="relative rounded-[2.5rem] border border-border/70 bg-white/90 p-8 shadow-2xl">
+            <div className="space-y-6 text-sm text-muted">
+              <p className="text-base font-semibold text-text">“It feels like silk and photographs like a dream.”</p>
+              {testimonials.map((review) => (
+                <div key={review.id} className="rounded-2xl border border-border/40 bg-white/80 p-4">
+                  <div className="text-xs uppercase tracking-wide text-muted">{review.name}</div>
+                  <p className="mt-2 text-sm text-text">{review.comment}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <header className="flex flex-col items-start justify-between gap-6 sm:flex-row sm:items-end">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted">Featherlight heroes</p>
+            <h2 className="mt-2 font-heading text-3xl text-text">Cult favourites, now in bloom</h2>
+          </div>
+          <Link href="/shop" className="rounded-full border border-border/70 px-5 py-2 text-sm font-medium text-text transition hover:border-accent hover:text-accent">
+            Shop all products
+          </Link>
+        </header>
+        <div className="mt-10 grid gap-6 md:grid-cols-3">
+          {featured.map((product) => (
+            <ProductCard key={product.id} product={product} />
+          ))}
+        </div>
+      </section>
+
+      <section id="ritual" className="rounded-[3rem] border border-border/60 bg-white/80 p-10 shadow-lg backdrop-blur">
+        <div className="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted">Our ritual</p>
+            <h2 className="mt-2 font-heading text-3xl text-text">Three steps to a feather-light finish</h2>
+          </div>
+          <Link href="/product/weightless-mineral-foundation" className="rounded-full bg-accent px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:shadow-md">
+            Try the hero set
+          </Link>
+        </div>
+        <div className="mt-8 grid gap-6 sm:grid-cols-3">
+          {ritualSteps.map((step) => (
+            <div key={step.title} className="rounded-2xl border border-border/60 bg-white/70 p-6 shadow-sm">
+              <h3 className="font-heading text-xl text-text">{step.title}</h3>
+              <p className="mt-3 text-sm text-muted">{step.detail}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="ingredients">
+        <div className="flex flex-col items-start justify-between gap-6 sm:flex-row sm:items-end">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted">Ingredient alchemy</p>
+            <h2 className="mt-2 font-heading text-3xl text-text">Mineral science meets plant soul</h2>
+          </div>
+          <span className="rounded-full bg-highlight/70 px-5 py-2 text-xs font-semibold uppercase tracking-wide text-text">
+            Dermatologist tested
+          </span>
+        </div>
+        <div className="mt-8 grid gap-6 sm:grid-cols-3">
+          {ingredientHighlights.map((item) => (
+            <div key={item.title} className="rounded-3xl border border-border/60 bg-white/70 p-6 shadow-sm backdrop-blur">
+              <h3 className="font-heading text-xl text-text">{item.title}</h3>
+              <p className="mt-3 text-sm text-muted">{item.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <div className="rounded-[3rem] border border-border/60 bg-gradient-to-r from-primary/80 via-white to-accent/10 p-10 shadow-xl">
+          <div className="grid gap-8 sm:grid-cols-[1.1fr_1fr] sm:items-center">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-muted">Stay in the know</p>
+              <h2 className="mt-2 font-heading text-3xl text-text">Workshops, shade launches and backstage tips.</h2>
+              <p className="mt-4 text-sm text-muted">
+                Join our beauty circle to be the first to experience limited drops, private classes and mineral skincare
+                secrets.
+              </p>
+            </div>
+            <form className="flex flex-col gap-4 sm:flex-row">
+              <input
+                type="email"
+                placeholder="you@example.com"
+                className="w-full rounded-full border border-border/70 bg-white/80 px-5 py-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-accent/30"
+              />
+              <button
+                type="submit"
+                className="rounded-full bg-accent px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:shadow-lg"
+              >
+                Join now
+              </button>
+            </form>
+          </div>
+        </div>
+      </section>
     </main>
   );
 }

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -1,9 +1,10 @@
 // Shop page with search and filter capabilities for Sprint 3
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Filters from '@/components/Filters';
 import ProductCard from '@/components/ProductCard';
+import { getDummyProducts } from '@/lib/dummyContent';
 
 interface Product {
   id: string;
@@ -12,24 +13,42 @@ interface Product {
   kind: string;
   variants: { priceCents: number; name: string; sku: string; hex?: string }[];
   collection?: { season?: string };
+  highlights?: string[];
 }
 
 export default function ShopPage() {
-  const [products, setProducts] = useState<Product[]>([]);
-  const [filtered, setFiltered] = useState<Product[]>([]);
+  const fallbackProducts = useMemo(() => getDummyProducts() as Product[], []);
+  const [products, setProducts] = useState<Product[]>(fallbackProducts);
+  const [filtered, setFiltered] = useState<Product[]>(fallbackProducts);
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState('');
   const [season, setSeason] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   // Fetch products on mount
   useEffect(() => {
     (async () => {
-      const res = await fetch('/api/products', { cache: 'no-store' });
-      const data = await res.json();
-      setProducts(data);
-      setFiltered(data);
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch('/api/products', { cache: 'no-store' });
+        if (!res.ok) {
+          throw new Error('Unable to load products at this time.');
+        }
+        const data = (await res.json()) as Product[];
+        setProducts(data);
+        setFiltered(data);
+      } catch (err: any) {
+        console.warn('Using fallback products for shop grid', err);
+        setProducts(fallbackProducts);
+        setFiltered(fallbackProducts);
+        setError('Showing our studio collection while we connect to Shopify.');
+      } finally {
+        setLoading(false);
+      }
     })();
-  }, []);
+  }, [fallbackProducts]);
 
   // Filter when query/category/season changes or products change
   useEffect(() => {
@@ -48,8 +67,18 @@ export default function ShopPage() {
   }, [query, category, season, products]);
 
   return (
-    <main className="mx-auto max-w-6xl px-4 py-12">
-      <h1 className="font-heading text-3xl mb-4">Shop</h1>
+    <main className="mx-auto max-w-6xl space-y-10 px-4 pb-16 pt-12">
+      <section className="rounded-[3rem] border border-border/60 bg-white/80 p-10 shadow-lg backdrop-blur">
+        <div className="flex flex-col gap-4">
+          <p className="text-xs uppercase tracking-wide text-muted">The mineral wardrobe</p>
+          <h1 className="font-heading text-4xl text-text">Shop the FeatherLite ritual</h1>
+          <p className="max-w-2xl text-sm text-muted">
+            Explore our edit of feather-light essentials. Every formula is infused with mineral pigments and botanicals to
+            deliver a fresh, luminous finish that feels like second skin.
+          </p>
+        </div>
+      </section>
+
       <Filters
         query={query}
         onQueryChange={setQuery}
@@ -58,14 +87,34 @@ export default function ShopPage() {
         season={season}
         onSeasonChange={setSeason}
       />
-      {filtered.length === 0 ? (
-        <p>No products found.</p>
-      ) : (
-        <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-6">
-          {filtered.map((p) => (
-            <ProductCard key={p.id} product={p} />
+
+      {error && <p className="rounded-2xl border border-border/60 bg-highlight/60 px-4 py-3 text-sm text-text">{error}</p>}
+
+      {loading ? (
+        <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div
+              key={index}
+              className="h-80 animate-pulse rounded-3xl border border-border/60 bg-white/60"
+            />
           ))}
         </div>
+      ) : filtered.length === 0 ? (
+        <div className="rounded-3xl border border-border/60 bg-white/70 p-10 text-center text-sm text-muted">
+          No products match those filters yet. Try clearing a filter or explore our seasonal edits.
+        </div>
+      ) : (
+        <>
+          <div className="flex items-center justify-between text-xs uppercase tracking-wide text-muted">
+            <span>{filtered.length} styles</span>
+            {query && <span>Searching for “{query}”</span>}
+          </div>
+          <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+            {filtered.map((p) => (
+              <ProductCard key={p.id} product={p} />
+            ))}
+          </div>
+        </>
       )}
     </main>
   );

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -1,10 +1,10 @@
 import { Dispatch, SetStateAction } from 'react';
 
 /**
- * Filters component for the shop page. Provides a search input and
- * dropdown filters for category and season. Uses controlled values
+ * Filters component for the shop page. Wrapped inside a frosted glass panel with rounded
+ * corners so it feels at home alongside the refreshed design. Uses controlled values
  * passed via props and notifies parent on change.
- */
+*/
 export default function Filters({
   query,
   onQueryChange,
@@ -21,37 +21,48 @@ export default function Filters({
   onSeasonChange: Dispatch<SetStateAction<string>>;
 }) {
   return (
-    <div className="flex flex-col md:flex-row gap-4 mb-6">
-      <input
-        type="text"
-        placeholder="Search products"
-        value={query}
-        onChange={(e) => onQueryChange(e.target.value)}
-        className="flex-1 border rounded-md p-2"
-      />
-      <select
-        value={category}
-        onChange={(e) => onCategoryChange(e.target.value)}
-        className="border rounded-md p-2"
-      >
-        <option value="">All Categories</option>
-        <option value="foundation">Foundation</option>
-        <option value="blush">Blush</option>
-        <option value="eyeshadow">Eyeshadow</option>
-        <option value="set">Sets</option>
-      </select>
-      <select
-        value={season}
-        onChange={(e) => onSeasonChange(e.target.value)}
-        className="border rounded-md p-2"
-      >
-        <option value="">All Seasons</option>
-        <option value="Year-Round">Year-Round</option>
-        <option value="Fall">Fall</option>
-        <option value="Winter">Winter</option>
-        <option value="Spring">Spring</option>
-        <option value="Summer">Summer</option>
-      </select>
+    <div className="mb-8 rounded-3xl border border-border/60 bg-white/70 p-6 shadow-sm backdrop-blur">
+      <div className="flex flex-col gap-4 md:flex-row md:items-end">
+        <label className="flex-1 text-sm font-medium text-text">
+          <span className="text-xs uppercase tracking-wide text-muted">Search</span>
+          <input
+            type="text"
+            placeholder="Search products"
+            value={query}
+            onChange={(e) => onQueryChange(e.target.value)}
+            className="mt-2 w-full rounded-full border border-border/60 bg-white/80 px-4 py-2 text-sm shadow-sm transition focus:outline-none focus:ring-2 focus:ring-accent/30"
+          />
+        </label>
+        <label className="md:w-48 text-sm font-medium text-text">
+          <span className="text-xs uppercase tracking-wide text-muted">Category</span>
+          <select
+            value={category}
+            onChange={(e) => onCategoryChange(e.target.value)}
+            className="mt-2 w-full rounded-full border border-border/60 bg-white/80 px-4 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-accent/30"
+          >
+            <option value="">All Categories</option>
+            <option value="foundation">Foundation</option>
+            <option value="blush">Blush</option>
+            <option value="eyeshadow">Eyeshadow</option>
+            <option value="set">Sets</option>
+          </select>
+        </label>
+        <label className="md:w-48 text-sm font-medium text-text">
+          <span className="text-xs uppercase tracking-wide text-muted">Season</span>
+          <select
+            value={season}
+            onChange={(e) => onSeasonChange(e.target.value)}
+            className="mt-2 w-full rounded-full border border-border/60 bg-white/80 px-4 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-accent/30"
+          >
+            <option value="">All Seasons</option>
+            <option value="Year-Round">Year-Round</option>
+            <option value="Fall">Fall</option>
+            <option value="Winter">Winter</option>
+            <option value="Spring">Spring</option>
+            <option value="Summer">Summer</option>
+          </select>
+        </label>
+      </div>
     </div>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,12 +5,62 @@
  * in future iterations.
  */
 export default function Footer() {
+  const year = new Date().getFullYear();
   return (
-    <footer className="mt-20 border-t bg-white">
-      <div className="mx-auto max-w-6xl px-4 py-8 text-sm text-gray-600">
-        <p>
-          © {new Date().getFullYear()} FeatherLite Cosmetics • Winston-Salem, NC
-        </p>
+    <footer className="mt-24 border-t border-border/60 bg-surface/80 backdrop-blur">
+      <div className="mx-auto grid max-w-6xl gap-10 px-4 py-12 md:grid-cols-4">
+        <div className="space-y-3">
+          <h2 className="font-heading text-lg text-text">FeatherLite</h2>
+          <p className="text-sm text-muted">
+            Clean, feather-light formulas crafted from six mineral essentials. Beauty that lets
+            your skin breathe.
+          </p>
+        </div>
+        <div>
+          <h3 className="font-semibold text-sm text-text">Explore</h3>
+          <ul className="mt-3 space-y-2 text-sm text-muted">
+            <li><a href="/shop" className="transition hover:text-accent">Shop All</a></li>
+            <li><a href="/shop?season=Spring" className="transition hover:text-accent">Seasonal Edits</a></li>
+            <li><a href="/#ritual" className="transition hover:text-accent">Ritual Guide</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-semibold text-sm text-text">Customer Care</h3>
+          <ul className="mt-3 space-y-2 text-sm text-muted">
+            <li><a href="#" className="transition hover:text-accent">Shipping &amp; Returns</a></li>
+            <li><a href="#" className="transition hover:text-accent">Shade Finder</a></li>
+            <li><a href="#" className="transition hover:text-accent">Contact Concierge</a></li>
+          </ul>
+        </div>
+        <div className="space-y-3">
+          <h3 className="font-semibold text-sm text-text">Join the glow list</h3>
+          <p className="text-sm text-muted">
+            Receive product drops, application tips and exclusive invites straight to your inbox.
+          </p>
+          <form className="flex gap-2">
+            <input
+              type="email"
+              placeholder="you@example.com"
+              className="w-full rounded-full border border-border/70 bg-white/80 px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40"
+            />
+            <button
+              type="submit"
+              className="rounded-full bg-accent px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:shadow-md"
+            >
+              Sign up
+            </button>
+          </form>
+        </div>
+      </div>
+      <div className="border-t border-border/60 bg-white/60">
+        <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-4 py-4 text-xs text-muted sm:flex-row">
+          <p>© {year} FeatherLite Cosmetics • Crafted in Winston-Salem, NC</p>
+          <div className="flex gap-4">
+            <a href="#" className="transition hover:text-accent">Privacy</a>
+            <a href="#" className="transition hover:text-accent">Terms</a>
+            <a href="#" className="transition hover:text-accent">Accessibility</a>
+          </div>
+        </div>
       </div>
     </footer>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,30 +4,49 @@ import Link from 'next/link';
 import { useCart } from './CartProvider';
 
 /**
- * Simple navigation bar displayed at the top of each page. Shows the
- * site logo, a link to the shop and a link to the cart with the
- * quantity of items currently in the cart. The quantity is derived
- * from the cart context.
+ * Polished top navigation with brand mark, quick links and a glowing cart pill.
+ * Cart quantity is sourced from the shared cart context so the badge updates in
+ * real time as visitors add products while browsing.
  */
 export default function Navbar() {
   const { items } = useCart();
   const count = items.reduce((sum, item) => sum + item.quantity, 0);
+  const navLinks = [
+    { href: '/shop', label: 'Shop' },
+    { href: '/shop?season=Year-Round', label: 'Collections' },
+    { href: '/#ritual', label: 'Our Ritual' },
+    { href: '/#ingredients', label: 'Ingredients' },
+  ];
   return (
-    <header className="sticky top-0 z-50 backdrop-blur bg-white/70 border-b">
-      <nav className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
-        <Link href="/" className="font-heading text-xl tracking-wide">
-          FeatherLite
-        </Link>
-        <div className="flex items-center gap-6">
-          <Link href="/shop" className="hover:underline">
-            Shop
+    <header className="sticky top-0 z-50 bg-white/80 backdrop-blur border-b border-border/60">
+      <nav className="mx-auto flex max-w-6xl items-center justify-between gap-6 px-4 py-4">
+        <div className="flex items-center gap-10">
+          <Link href="/" className="font-heading text-xl tracking-tight text-text">
+            FeatherLite
           </Link>
-          <Link href="/cart" className="relative flex items-center gap-1">
-            <span className="rounded-full border px-3 py-1 hover:bg-primary/20">
-              Cart
-            </span>
+          <div className="hidden items-center gap-6 md:flex">
+            {navLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="text-sm font-medium text-muted transition hover:text-text"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <Link
+            href="/shop"
+            className="hidden rounded-full border border-border/70 px-4 py-2 text-sm font-medium text-text transition hover:border-accent hover:text-accent md:inline-flex"
+          >
+            Browse
+          </Link>
+          <Link href="/cart" className="relative inline-flex items-center gap-2 rounded-full bg-accent px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:shadow-md">
+            Cart
             {count > 0 && (
-              <span className="absolute -top-1 -right-2 bg-accent text-white text-xs rounded-full px-1">
+              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-white text-xs font-semibold text-accent">
                 {count}
               </span>
             )}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -5,12 +5,10 @@ import ShadeSwatches, { Shade } from './ShadeSwatches';
 import { imageForSlug } from '@/lib/paths';
 
 /**
- * A card used on the shop page to represent a single product. Displays
- * a placeholder image, the product name, kind and price. If shade
- * information is available on the product's variants a row of small
- * coloured dots will render below the kind. Clicking the card navigates
- * to the product detail page.
- */
+ * A card used on the shop page to represent a single product. Updated with a subtle
+ * elevation effect, collection chips and highlight bullets so the grid feels more
+ * editorial. Shade dots still appear when hex values are available.
+*/
 export default function ProductCard({ product }: { product: any }) {
   // Compute the display price from the first variant. The API returns
   // priceCents as an integer number of cents.
@@ -32,19 +30,44 @@ export default function ProductCard({ product }: { product: any }) {
   return (
     <Link
       href={`/product/${product.slug}`}
-      className="block border rounded-2xl overflow-hidden bg-white hover:shadow-md transition"
+      className="group relative block overflow-hidden rounded-3xl border border-border/60 bg-white/80 shadow-sm transition hover:-translate-y-1 hover:shadow-xl"
     >
-      {/* Render the product's image using the manifest helper. If no image is found, a placeholder is used. */}
-      <img
-        src={imageForSlug(product.slug)}
-        alt={product.name || 'Product image'}
-        className="aspect-square w-full object-cover"
-      />
-      <div className="p-4">
-        <div className="font-heading">{product.name}</div>
-        <div className="text-sm text-gray-600 capitalize">{product.kind}</div>
-        {shades.length > 0 && <ShadeSwatches shades={shades} />}
-        {price && <div className="mt-2 text-sm">{price}</div>}
+      <div className="relative aspect-square overflow-hidden">
+        <img
+          src={imageForSlug(product.slug)}
+          alt={product.name || 'Product image'}
+          className="h-full w-full object-cover transition duration-700 group-hover:scale-105"
+        />
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-transparent via-transparent to-accent/20 opacity-0 transition duration-500 group-hover:opacity-100" />
+      </div>
+      <div className="flex flex-col gap-3 p-5">
+        <div className="flex items-center justify-between text-xs uppercase tracking-wide text-muted">
+          <span>{product.collection?.season ?? 'Signature'}</span>
+          {price && (
+            <span className="rounded-full bg-highlight/70 px-3 py-1 font-semibold text-text">
+              {price}
+            </span>
+          )}
+        </div>
+        <div>
+          <div className="font-heading text-lg text-text">{product.name}</div>
+          <div className="text-sm capitalize text-muted">{product.kind}</div>
+        </div>
+        {shades.length > 0 && (
+          <div className="mt-1">
+            <ShadeSwatches shades={shades} />
+          </div>
+        )}
+        {product.highlights && (
+          <ul className="mt-1 space-y-1 text-xs text-muted/80">
+            {product.highlights.slice(0, 2).map((point: string) => (
+              <li key={point} className="flex items-start gap-2">
+                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-accent/60" />
+                <span>{point}</span>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </Link>
   );

--- a/src/components/ReviewList.tsx
+++ b/src/components/ReviewList.tsx
@@ -1,6 +1,7 @@
 /**
- * ReviewList component renders a list of customer reviews for a product.
- * Accepts an array of review objects with name, rating and comment.
+ * ReviewList component renders customer reviews in frosted cards. Accepts an array of
+ * review objects with name, rating and comment, formatting dates and ratings with the
+ * refreshed brand styling.
  */
 export type Review = {
   id: string;
@@ -15,19 +16,24 @@ export default function ReviewList({ reviews }: { reviews: Review[] }) {
     return <p className="text-sm text-gray-500">No reviews yet.</p>;
   }
   return (
-    <div className="space-y-4 mt-6">
+    <div className="mt-6 grid gap-4 md:grid-cols-2">
       {reviews.map((r) => (
-        <div key={r.id} className="border-b pb-4">
-          <div className="flex items-center gap-2">
-            <span className="font-medium">{r.name ?? 'Anonymous'}</span>
-            <span className="text-yellow-500">
-              {Array.from({ length: 5 }).map((_, i) => (
-                <span key={i}>{i < r.rating ? '★' : '☆'}</span>
-              ))}
+        <div
+          key={r.id}
+          className="rounded-3xl border border-border/60 bg-white/80 p-5 shadow-sm backdrop-blur transition hover:-translate-y-0.5 hover:shadow-md"
+        >
+          <div className="flex items-center justify-between">
+            <span className="font-semibold text-text">{r.name ?? 'Anonymous'}</span>
+            <span className="text-xs uppercase tracking-wide text-muted">
+              {new Date(r.createdAt).toLocaleDateString()}
             </span>
           </div>
-          <p className="mt-1 text-sm text-gray-700">{r.comment}</p>
-          <p className="mt-1 text-xs text-gray-500">{new Date(r.createdAt).toLocaleDateString()}</p>
+          <div className="mt-2 flex items-center gap-1 text-sm text-accent">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <span key={i}>{i < r.rating ? '★' : '☆'}</span>
+            ))}
+          </div>
+          <p className="mt-3 text-sm leading-relaxed text-muted">{r.comment}</p>
         </div>
       ))}
     </div>

--- a/src/components/ShadeSwatches.tsx
+++ b/src/components/ShadeSwatches.tsx
@@ -18,12 +18,12 @@ export type Shade = {
 export default function ShadeSwatches({ shades }: { shades: Shade[] }) {
   if (!shades || shades.length === 0) return null;
   return (
-    <div className="flex gap-2 mt-2" aria-label="Available shades">
+    <div className="mt-2 flex gap-2" aria-label="Available shades">
       {shades.map((s) => (
         <span
           key={s.name}
           title={s.name}
-          className="h-4 w-4 rounded-full border"
+          className="h-4 w-4 rounded-full border border-white/70 shadow-sm ring-1 ring-border/40"
           style={{ backgroundColor: s.hex }}
         />
       ))}

--- a/src/lib/dummyContent.ts
+++ b/src/lib/dummyContent.ts
@@ -1,0 +1,269 @@
+export type DummyVariant = {
+  id: string;
+  name: string;
+  sku: string;
+  priceCents: number;
+  hex?: string;
+  shopifyVariantId: string;
+};
+
+export type DummyImage = {
+  id: string;
+  url: string;
+  alt?: string;
+};
+
+export type DummyProduct = {
+  id: string;
+  slug: string;
+  name: string;
+  kind: string;
+  description: string;
+  ingredients: string;
+  imagePath?: string;
+  thumbnailPath?: string;
+  collection?: { season?: string } | null;
+  variants: DummyVariant[];
+  images?: DummyImage[];
+  highlights?: string[];
+};
+
+export type DummyReview = {
+  id: string;
+  productSlug: string;
+  name: string;
+  rating: number;
+  comment: string;
+  createdAt: string;
+};
+
+const DUMMY_PRODUCTS: DummyProduct[] = [
+  {
+    id: 'prod-weightless-foundation',
+    slug: 'weightless-mineral-foundation',
+    name: 'Weightless Mineral Foundation',
+    kind: 'foundation',
+    description:
+      'An airy mineral foundation that blurs imperfections and nourishes skin with a satin, second-skin finish.',
+    ingredients:
+      'Mica, Zinc Oxide, Rice Powder, Squalane, Aloe Leaf Extract, Vitamin E.',
+    collection: { season: 'Year-Round' },
+    imagePath: '/images/placeholders/product-placeholder.svg',
+    variants: [
+      {
+        id: 'var-foundation-porcelain',
+        name: 'Porcelain',
+        sku: 'FL-FOUND-01',
+        priceCents: 3200,
+        hex: '#F7E6DB',
+        shopifyVariantId: 'gid://shopify/ProductVariant/foundation-porcelain',
+      },
+      {
+        id: 'var-foundation-vanilla',
+        name: 'Vanilla',
+        sku: 'FL-FOUND-02',
+        priceCents: 3200,
+        hex: '#F0D5C2',
+        shopifyVariantId: 'gid://shopify/ProductVariant/foundation-vanilla',
+      },
+      {
+        id: 'var-foundation-sand',
+        name: 'Sand',
+        sku: 'FL-FOUND-03',
+        priceCents: 3200,
+        hex: '#D9B093',
+        shopifyVariantId: 'gid://shopify/ProductVariant/foundation-sand',
+      },
+      {
+        id: 'var-foundation-mocha',
+        name: 'Mocha',
+        sku: 'FL-FOUND-04',
+        priceCents: 3200,
+        hex: '#8C5B45',
+        shopifyVariantId: 'gid://shopify/ProductVariant/foundation-mocha',
+      },
+    ],
+    highlights: [
+      '24-hour breathable wear',
+      'Infused with calming botanicals',
+      'Buildable sheer-to-medium coverage',
+    ],
+  },
+  {
+    id: 'prod-silk-veil-powder',
+    slug: 'silk-veil-setting-powder',
+    name: 'Silk Veil Setting Powder',
+    kind: 'set',
+    description:
+      'A translucent finishing powder that softens texture and locks in makeup without muting your glow.',
+    ingredients: 'Kaolin Clay, Rice Bran, Hyaluronic Acid, Chamomile Flower Powder.',
+    collection: { season: 'Spring' },
+    imagePath: '/images/placeholders/product-placeholder.svg',
+    variants: [
+      {
+        id: 'var-powder-translucent',
+        name: 'Translucent',
+        sku: 'FL-POW-01',
+        priceCents: 2600,
+        shopifyVariantId: 'gid://shopify/ProductVariant/powder-translucent',
+      },
+      {
+        id: 'var-powder-rose',
+        name: 'Soft Rose',
+        sku: 'FL-POW-02',
+        priceCents: 2600,
+        shopifyVariantId: 'gid://shopify/ProductVariant/powder-rose',
+      },
+    ],
+    highlights: [
+      'Blurs texture with photo-soft focus',
+      'Controls shine without drying skin',
+      'Infused with hyaluronic acid for comfort',
+    ],
+  },
+  {
+    id: 'prod-luminous-blush',
+    slug: 'luminous-mineral-blush',
+    name: 'Luminous Mineral Blush Duo',
+    kind: 'blush',
+    description:
+      'Silky mineral blushes baked with plant oils for a lit-from-within flush that melts into skin.',
+    ingredients: 'Mica, Rosehip Oil, Shea Butter, Hibiscus Extract, Vitamin C.',
+    collection: { season: 'Summer' },
+    imagePath: '/images/placeholders/product-placeholder.svg',
+    variants: [
+      {
+        id: 'var-blush-dawn',
+        name: 'Soft Dawn',
+        sku: 'FL-BLUSH-01',
+        priceCents: 2800,
+        hex: '#F5A0A9',
+        shopifyVariantId: 'gid://shopify/ProductVariant/blush-dawn',
+      },
+      {
+        id: 'var-blush-horizon',
+        name: 'Golden Horizon',
+        sku: 'FL-BLUSH-02',
+        priceCents: 2800,
+        hex: '#EB7965',
+        shopifyVariantId: 'gid://shopify/ProductVariant/blush-horizon',
+      },
+    ],
+    highlights: [
+      'Baked minerals for a seamless blend',
+      'Dual shades for custom colour',
+      'Antioxidant-rich botanicals protect skin',
+    ],
+  },
+  {
+    id: 'prod-horizon-eye',
+    slug: 'horizon-eye-quartet',
+    name: 'Horizon Eye Quartet',
+    kind: 'eyeshadow',
+    description:
+      'Four weightless mineral shadows inspired by sunrise light, with buttery mattes and prismatic shimmers.',
+    ingredients: 'Mica, Jojoba Oil, Sunflower Seed Wax, Calendula Extract.',
+    collection: { season: 'Fall' },
+    imagePath: '/images/placeholders/product-placeholder.svg',
+    variants: [
+      {
+        id: 'var-eye-quartet',
+        name: 'Sunrise Horizon',
+        sku: 'FL-EYE-01',
+        priceCents: 4200,
+        shopifyVariantId: 'gid://shopify/ProductVariant/eye-horizon',
+      },
+    ],
+    highlights: [
+      'Feather-light mineral pigments',
+      'Crease-resistant wear for 12 hours',
+      'Shimmers infused with light-reflecting pearls',
+    ],
+  },
+];
+
+const DUMMY_REVIEWS: DummyReview[] = [
+  {
+    id: 'rev-1',
+    productSlug: 'weightless-mineral-foundation',
+    name: 'Amelia R.',
+    rating: 5,
+    comment:
+      'My skin still feels like skin—just smoother. The coverage is buildable and never cakey.',
+    createdAt: new Date('2024-04-12').toISOString(),
+  },
+  {
+    id: 'rev-2',
+    productSlug: 'weightless-mineral-foundation',
+    name: 'Priya S.',
+    rating: 4,
+    comment: 'A beautiful base that wears all day. I love the calming ingredients inside.',
+    createdAt: new Date('2024-05-01').toISOString(),
+  },
+  {
+    id: 'rev-3',
+    productSlug: 'silk-veil-setting-powder',
+    name: 'Jordan P.',
+    rating: 5,
+    comment: 'Locks makeup in place without flattening my glow. A forever staple.',
+    createdAt: new Date('2024-03-22').toISOString(),
+  },
+  {
+    id: 'rev-4',
+    productSlug: 'luminous-mineral-blush',
+    name: 'Stella M.',
+    rating: 5,
+    comment: 'The duo compact makes it easy to switch from day to night. Melts into my skin!',
+    createdAt: new Date('2024-02-08').toISOString(),
+  },
+  {
+    id: 'rev-5',
+    productSlug: 'horizon-eye-quartet',
+    name: 'Tessa W.',
+    rating: 4,
+    comment: 'Feather-light pigment with zero fallout. The shimmers are stunning.',
+    createdAt: new Date('2024-01-18').toISOString(),
+  },
+];
+
+const VARIANT_BY_SHOPIFY_ID = new Map(
+  DUMMY_PRODUCTS.flatMap((product) =>
+    product.variants.map((variant) => [variant.shopifyVariantId, { product, variant } as const])
+  )
+);
+
+const VARIANT_BY_SKU = new Map(
+  DUMMY_PRODUCTS.flatMap((product) => product.variants.map((variant) => [variant.sku, { product, variant } as const]))
+);
+
+export function getDummyProducts(): DummyProduct[] {
+  return DUMMY_PRODUCTS;
+}
+
+export function getDummyProduct(slug: string): DummyProduct | undefined {
+  return DUMMY_PRODUCTS.find((product) => product.slug === slug);
+}
+
+export function getDummyReviews(productSlug: string): DummyReview[] {
+  return DUMMY_REVIEWS.filter((review) => review.productSlug === productSlug);
+}
+
+export function getDummyVariantByShopifyId(shopifyVariantId: string | null | undefined) {
+  if (!shopifyVariantId) return undefined;
+  return VARIANT_BY_SHOPIFY_ID.get(shopifyVariantId);
+}
+
+export function getDummyVariantBySku(sku: string | null | undefined) {
+  if (!sku) return undefined;
+  return VARIANT_BY_SKU.get(sku);
+}
+
+export function getDummyVariantCatalog() {
+  return Array.from(VARIANT_BY_SHOPIFY_ID.values()).map(({ product, variant }) => ({
+    merchandiseId: variant.shopifyVariantId,
+    sku: variant.sku,
+    title: `${product.name}${variant.name !== 'Default' ? ` – ${variant.name}` : ''}`,
+    priceCents: variant.priceCents,
+    currencyCode: 'USD',
+  }));
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -19,22 +19,6 @@ const REQUIRED_ENV_VARS: EnvKey[] = [
   'SHOPIFY_STOREFRONT_ACCESS_TOKEN',
   'SHOPIFY_ADMIN_ACCESS_TOKEN',
   'SHOPIFY_WEBHOOK_SECRET',
-] as const;
-
-if (process.env.SKIP_ENV_VALIDATION !== 'true') {
-  const missing = REQUIRED_ENV_VARS.filter((name) => {
-    const value = process.env[name];
-    return value === undefined || value === '';
-  });
-
-  if (missing.length > 0) {
-    throw new Error(
-      `Missing required environment variables: ${missing.join(', ')}`,
-    );
-  }
-}
-
-export {};
 ];
 
 function isMissing(value: string | undefined | null): value is undefined | null | '' {
@@ -43,7 +27,7 @@ function isMissing(value: string | undefined | null): value is undefined | null 
 
 const missing = REQUIRED_ENV_VARS.filter((key) => isMissing(process.env[key]));
 
-if (missing.length > 0) {
+if (missing.length > 0 && process.env.SKIP_ENV_VALIDATION !== 'true') {
   const message = `Missing required environment variables: ${missing.join(', ')}`;
   if (process.env.NODE_ENV === 'production') {
     throw new Error(message);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,10 +4,14 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: '#D6D1D1',
-        accent: '#3DA212',
-        background: '#FFFFFF',
-        text: '#000000',
+        primary: '#F6ECEF',
+        accent: '#7C5CFC',
+        background: '#FFFBF6',
+        surface: '#FFFFFF',
+        text: '#2B1D33',
+        muted: '#6C5D72',
+        highlight: '#FCDAD5',
+        border: '#E4D9EB',
       },
       fontFamily: {
         heading: ['\'Crimson Pro\'', 'serif'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -15,10 +19,27 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/components/*": ["./src/components/*"],
-      "@/lib/*": ["./src/lib/*"]
-    }
+      "@/components/*": [
+        "./src/components/*"
+      ],
+      "@/lib/*": [
+        "./src/lib/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "prisma/**"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "prisma/**"
+  ]
 }


### PR DESCRIPTION
## Summary
- add curated dummy products, variants, and reviews to power offline-friendly experiences
- update Shopify helpers and API routes to fall back to mock data whenever the live services are unavailable
- refresh the home, shop, product, and cart pages with the new FeatherLite visual system and frosted-glass components

## Testing
- npm run build *(fails: Google Fonts cannot be fetched inside the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dee3f78bd0832e9f377139194f052a