### PR TITLE
Set Vercel runtime to nodejs18.x

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,10 @@
   "framework": "nextjs",
   "buildCommand": "npm run prisma:deploy && npm run build",
   "installCommand": "npm install",
-  "outputDirectory": ".next"
+  "outputDirectory": ".next",
+  "functions": {
+    "**": {
+      "runtime": "nodejs18.x"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add a functions runtime configuration to vercel.json to use the supported nodejs18.x runtime

## Testing
- npx vercel build *(fails: npm registry access is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e030f45c20832eb813f8da6bc7f919