### PR TITLE
Add configuration status API and admin readiness banner

### DIFF
--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -1,0 +1,80 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+import { NextResponse } from 'next/server';
+import { env } from '@/lib/env';
+import { isShopifyAdminConfigured, isShopifyStorefrontConfigured } from '@/lib/shopify';
+
+const STATUS_DEFINITIONS = [
+  {
+    id: 'database',
+    label: 'Database connection',
+    configured: () => Boolean(process.env.DATABASE_URL && process.env.DATABASE_URL.trim()),
+    help: 'Set DATABASE_URL to your PostgreSQL connection string including the ?schema parameter.',
+    category: 'platform' as const,
+  },
+  {
+    id: 'reviewAdmin',
+    label: 'Review admin access',
+    configured: () =>
+      Boolean(
+        env.REVIEW_ADMIN_EMAIL &&
+          env.REVIEW_ADMIN_PASSWORD_HASH &&
+          env.REVIEW_ADMIN_SECRET &&
+          env.REVIEW_ADMIN_SECRET.length >= 32
+      ),
+    help: 'Populate REVIEW_ADMIN_EMAIL, REVIEW_ADMIN_PASSWORD_HASH and REVIEW_ADMIN_SECRET so moderation login works.',
+    category: 'platform' as const,
+  },
+  {
+    id: 'shopifyStorefront',
+    label: 'Shopify Storefront API',
+    configured: () => isShopifyStorefrontConfigured(),
+    help: 'Set SHOPIFY_STORE_DOMAIN and SHOPIFY_STOREFRONT_ACCESS_TOKEN to load live catalog data.',
+    category: 'shopify' as const,
+  },
+  {
+    id: 'shopifyAdmin',
+    label: 'Shopify Admin API',
+    configured: () => isShopifyAdminConfigured(),
+    help: 'Set SHOPIFY_ADMIN_ACCESS_TOKEN to enable product and order syncing.',
+    category: 'shopify' as const,
+  },
+  {
+    id: 'shopifyWebhooks',
+    label: 'Shopify webhooks',
+    configured: () => Boolean(env.SHOPIFY_WEBHOOK_SECRET),
+    help: 'Set SHOPIFY_WEBHOOK_SECRET to verify webhooks from your Shopify admin app.',
+    category: 'shopify' as const,
+  },
+] as const;
+
+type StatusDefinition = (typeof STATUS_DEFINITIONS)[number];
+
+type StatusResponse = {
+  id: StatusDefinition['id'];
+  label: string;
+  category: StatusDefinition['category'];
+  configured: boolean;
+  help: string;
+};
+
+export async function GET() {
+  const statuses: StatusResponse[] = STATUS_DEFINITIONS.map((definition) => ({
+    id: definition.id,
+    label: definition.label,
+    category: definition.category,
+    configured: definition.configured(),
+    help: definition.help,
+  }));
+
+  const pending = statuses.filter((status) => !status.configured);
+  const summary = {
+    ready: pending.length === 0,
+    pending: pending.map((status) => status.id),
+    shopifyReady: pending.every((status) => status.category !== 'shopify'),
+  };
+
+  return NextResponse.json({ statuses, summary });
+}

--- a/src/components/AdminReviewDashboard.tsx
+++ b/src/components/AdminReviewDashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from 'react';
+import SystemStatusBanner from './SystemStatusBanner';
 
 type ModerationReview = {
   id: string;
@@ -84,6 +85,7 @@ export default function AdminReviewDashboard() {
 
   return (
     <div className="space-y-8">
+      <SystemStatusBanner />
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="font-heading text-3xl text-text">Review moderation</h1>

--- a/src/components/SystemStatusBanner.tsx
+++ b/src/components/SystemStatusBanner.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+
+type Status = {
+  id: string;
+  label: string;
+  category: 'platform' | 'shopify';
+  configured: boolean;
+  help: string;
+};
+
+type StatusSummary = {
+  ready: boolean;
+  pending: string[];
+  shopifyReady: boolean;
+};
+
+type StatusResponse = {
+  statuses: Status[];
+  summary: StatusSummary;
+};
+
+export default function SystemStatusBanner() {
+  const [data, setData] = useState<StatusResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch('/api/status', { cache: 'no-store' });
+        if (!res.ok) {
+          throw new Error('Unable to verify configuration.');
+        }
+        const json = (await res.json()) as StatusResponse;
+        if (!cancelled) {
+          setData(json);
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setError(err?.message || 'Unable to verify configuration.');
+        }
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <div className="rounded-3xl border border-red-200 bg-red-50 px-5 py-4 text-sm text-red-700 shadow-sm">
+        {error}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="rounded-3xl border border-border/50 bg-white/70 px-5 py-4 text-sm text-muted shadow-sm" role="status">
+        Checking Shopify and database configuration…
+      </div>
+    );
+  }
+
+  const { summary, statuses } = data;
+  const readyLabel = summary.ready
+    ? 'All systems are configured. FeatherLite is ready for launch.'
+    : summary.shopifyReady
+      ? 'Shopify is ready. Complete the remaining platform tasks before launch.'
+      : 'Connect Shopify and finish the outstanding tasks to go live.';
+
+  return (
+    <section className="space-y-4 rounded-3xl border border-border/60 bg-white/80 p-6 shadow-sm">
+      <div>
+        <h2 className="font-heading text-2xl text-text">Launch readiness</h2>
+        <p className="mt-1 text-sm text-muted">{readyLabel}</p>
+      </div>
+      <ul className="grid gap-3 md:grid-cols-2">
+        {statuses.map((status) => (
+          <li
+            key={status.id}
+            className="flex flex-col gap-2 rounded-2xl border border-border/50 bg-white/70 p-4 text-sm text-muted shadow-sm"
+          >
+            <div className="flex items-center justify-between">
+              <span className="font-semibold text-text">{status.label}</span>
+              <span
+                className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${
+                  status.configured
+                    ? 'bg-emerald-100 text-emerald-700'
+                    : status.category === 'shopify'
+                      ? 'bg-amber-100 text-amber-700'
+                      : 'bg-red-100 text-red-700'
+                }`}
+              >
+                {status.configured ? 'Ready' : 'Action needed'}
+              </span>
+            </div>
+            {!status.configured && <p>{status.help}</p>}
+            {status.configured && status.category === 'shopify' && (
+              <p className="text-xs text-muted">Live Shopify data will appear in the storefront.</p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a `/api/status` endpoint that reports Shopify, database, and review admin configuration readiness
- surface a launch readiness banner on the admin moderation dashboard backed by the new status API so missing steps are clear

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e15e6dabb8832ea664545fda4bde10